### PR TITLE
Remove trustedApps asociated to a wallet when a wallet is removed

### DIFF
--- a/packages/extension/src/contexts/WalletContext/WalletContext.tsx
+++ b/packages/extension/src/contexts/WalletContext/WalletContext.tsx
@@ -12,6 +12,7 @@ import {
   loadSelectedWallet,
   loadWallets,
   numbersToSeed,
+  removeWalletFromTrustedApp,
   removeWallets,
   saveData,
   saveSelectedWallet,
@@ -284,6 +285,8 @@ const WalletProvider: FC = ({ children }) => {
             mnemonic
           })
         );
+        // We also want to remove the trusted apps associated to this wallet
+        removeWalletFromTrustedApp(walletIndex);
         saveData(STORAGE_WALLETS, encrypt(JSON.stringify(walletToSave), password as string));
       }
     },

--- a/packages/extension/src/utils/trustedApps.ts
+++ b/packages/extension/src/utils/trustedApps.ts
@@ -87,6 +87,20 @@ export const removeTrustedApp = (url: string, walletIndex: number): TrustedApp[]
   return trustedApps[walletIndex];
 };
 
+export const removeWalletFromTrustedApp = (walletIndex: number): void => {
+  const trustedApps: TrustedApp[][] = JSON.parse(loadData(STORAGE_TRUSTED_APPS) || '[[]]');
+
+  if (trustedApps[walletIndex]) {
+    trustedApps.splice(walletIndex, 1);
+  }
+
+  try {
+    saveData(STORAGE_TRUSTED_APPS, JSON.stringify(trustedApps));
+  } catch (e) {
+    throw e;
+  }
+};
+
 // Checks if the trustedApp includes all the permissions
 export const checkPermissions = (trustedApp: TrustedApp, permissions: Permission[]): boolean => {
   return permissions.every((permission) => trustedApp.permissions.includes(permission));


### PR DESCRIPTION
### Remove TrustedApp associated to wallet
Now the TrustedApp associated to a wallet is removed when we remove the wallet as well.

Commits:

- [Remove trustedApps asociated to a wallet when a wallet is removed](https://github.com/GemWallet/gemwallet-extension/commit/aa3eda0c3958d37ec6604efd9a533ddfd8a7e75a)