### PR TITLE
Remove the NFTDevNet and add the AMMDevNet

### DIFF
--- a/packages/constants/src/network/network.constant.ts
+++ b/packages/constants/src/network/network.constant.ts
@@ -2,14 +2,14 @@ export enum Network {
   MAINNET = 'Mainnet',
   TESTNET = 'Testnet',
   DEVNET = 'Devnet',
-  NFT_DEVNET = 'NFTDevnet'
+  AMM_DEVNET = 'AMM-Devnet'
 }
 
 export enum NetworkServer {
   MAINNET = 'wss://xrplcluster.com',
   TESTNET = 'wss://s.altnet.rippletest.net:51233',
   DEVNET = 'wss://s.devnet.rippletest.net:51233',
-  NFT_DEVNET = 'wss://xls20-sandbox.rippletest.net:51233'
+  AMM_DEVNET = 'wss://amm.devnet.rippletest.net:51233'
 }
 
 export const NETWORK = {
@@ -29,9 +29,9 @@ export const NETWORK = {
     server: NetworkServer.DEVNET,
     description: 'A preview of upcoming features, where unstable changes are tested out.'
   },
-  [Network.NFT_DEVNET]: {
-    name: Network.NFT_DEVNET,
-    server: NetworkServer.NFT_DEVNET,
-    description: 'A preview of the XLS-20d standard for non-fungible tokens on the XRP Ledger.'
+  [Network.AMM_DEVNET]: {
+    name: Network.AMM_DEVNET,
+    server: NetworkServer.AMM_DEVNET,
+    description: 'XLS-30d Automated Market Makers preview network.'
   }
 };

--- a/packages/extension/cypress/e2e/networks.cy.ts
+++ b/packages/extension/cypress/e2e/networks.cy.ts
@@ -69,7 +69,7 @@ describe('Switch networks', () => {
     });
   });
 
-  it('Switch from Devnet (localStorage) to NFTDevnet', () => {
+  it('Switch from Devnet (localStorage) to AMMDevnet', () => {
     // Devnet should be the network from localStorage
     cy.get('div[data-testid="network-indicator"]').should('have.text', 'Devnet');
 
@@ -79,12 +79,12 @@ describe('Switch networks', () => {
       .find('header')
       .should('have.text', 'Change Network');
 
-    // Select the NFTDevnet network
-    cy.contains('button', 'NFTDevnet').click();
+    // Select the AMMDevnet network
+    cy.contains('button', 'AMM-Devnet').click();
 
-    // Make sure that the network is switched to NFTDevnet
+    // Make sure that the network is switched to AMMDevnet
     cy.get('div[data-testid="loading"]').should('be.visible');
-    cy.get('div[data-testid="network-indicator"]').should('have.text', 'NFTDevnet');
+    cy.get('div[data-testid="network-indicator"]').should('have.text', 'AMM-Devnet');
 
     // Save the current state of the localStorage
     cy.window().then((win) => {
@@ -92,9 +92,9 @@ describe('Switch networks', () => {
     });
   });
 
-  it('Switch from NFTDevnet (localStorage) to Mainnet', () => {
-    // NFTDevnet should be the network from localStorage
-    cy.get('div[data-testid="network-indicator"]').should('have.text', 'NFTDevnet');
+  it('Switch from AMMDevnet (localStorage) to Mainnet', () => {
+    // AMMDevnet should be the network from localStorage
+    cy.get('div[data-testid="network-indicator"]').should('have.text', 'AMM-Devnet');
 
     // Open the change network window
     cy.get('div[data-testid="network-indicator"]').click();


### PR DESCRIPTION
### Remoce the NFTDevNet and add the AMMDevNet
Now that the NFTDevNet is deprecated and the XLS-20 is on the Testnet we can now remove it from GemWallet.
The AMMDevNet allows user to develop with the XLS-30.

Commits:

- [Remove the NFTDevNet and add the AMMDevNet](https://github.com/GemWallet/gemwallet-extension/commit/1851fdc824b6736192d1328537b81d05c13ed548)