### PR TITLE
Default network to Mainnet if loaded network is not supported

### DIFF
--- a/packages/extension/src/utils/network.ts
+++ b/packages/extension/src/utils/network.ts
@@ -15,7 +15,7 @@ export const saveNetwork = (network: Network) => {
 export const loadNetwork = () => {
   try {
     const data = loadData(STORAGE_NETWORK);
-    if (data) {
+    if (data && NETWORK[data as Network]) {
       return NETWORK[data as Network];
     }
     return NETWORK[Network.MAINNET];


### PR DESCRIPTION
### Default network to Mainnet if loaded network is not supported
Makes sure to default network to Mainnet if loaded network is not supported

Commits:

- [Default network to Mainnet if loaded network is not supported](https://github.com/GemWallet/gemwallet-extension/commit/5b463a58549c9d6ecb4141325a409576ed1c741d)