### PR TITLE
Have signMessage return the signer public key

### DIFF
--- a/packages/api/src/signMessage/signMessage.ts
+++ b/packages/api/src/signMessage/signMessage.ts
@@ -15,6 +15,7 @@ export const signMessage = async (message: string): Promise<SignMessageResponse>
    * - type: 'response'
    * - result:
    *    - signedMessage: signed message
+   *    - signingPubKey: signer public key
    *
    * if the user rejects the transaction:
    * - type: 'reject'

--- a/packages/constants/src/payload/payload.types.ts
+++ b/packages/constants/src/payload/payload.types.ts
@@ -298,7 +298,8 @@ export interface GetPublicKeyResponseDeprecated {
   publicKey: string | null | undefined;
 }
 
-export interface SignMessageResponse extends BaseResponse<{ signedMessage: string }> {}
+export interface SignMessageResponse
+  extends BaseResponse<{ signedMessage: string; signingPubKey: string }> {}
 
 export interface SignMessageResponseDeprecated {
   signedMessage: string | null | undefined;

--- a/packages/extension/src/components/pages/SignMessage/SignMessage.tsx
+++ b/packages/extension/src/components/pages/SignMessage/SignMessage.tsx
@@ -60,8 +60,12 @@ export const SignMessage: FC = () => {
   const { id, url, title, favicon, message } = payload;
 
   const handleSendMessage = useCallback(
-    (messagePayload: { signedMessage: string | null | undefined; error?: Error }) => {
-      const { signedMessage, error } = messagePayload;
+    (messagePayload: {
+      signedMessage: string | null | undefined;
+      signingPubKey?: string;
+      error?: Error;
+    }) => {
+      const { signedMessage, signingPubKey, error } = messagePayload;
 
       let message:
         | ReceiveSignMessageBackgroundMessage
@@ -81,7 +85,10 @@ export const SignMessage: FC = () => {
           payload: {
             id,
             type: ResponseType.Response,
-            result: signedMessage ? { signedMessage: signedMessage } : undefined,
+            result:
+              signedMessage && signingPubKey
+                ? { signedMessage: signedMessage, signingPubKey: signingPubKey }
+                : undefined,
             error: error ? serializeError(error) : undefined
           }
         };
@@ -109,10 +116,13 @@ export const SignMessage: FC = () => {
 
   const handleSign = useCallback(() => {
     try {
-      const signature = signMessage(message);
-      handleSendMessage({ signedMessage: signature });
+      const response = signMessage(message);
+      handleSendMessage({
+        signedMessage: response?.signature,
+        signingPubKey: response?.signingPubKey
+      });
     } catch (e) {
-      handleSendMessage({ signedMessage: undefined, error: e as Error });
+      handleSendMessage({ signedMessage: undefined, signingPubKey: undefined, error: e as Error });
     }
   }, [handleSendMessage, message, signMessage]);
 

--- a/packages/extension/src/contexts/LedgerContext/LedgerContext.tsx
+++ b/packages/extension/src/contexts/LedgerContext/LedgerContext.tsx
@@ -40,6 +40,11 @@ import { toXRPLMemos, toXRPLSigners } from '../../utils';
 import { useNetwork } from '../NetworkContext';
 import { useWallet } from '../WalletContext';
 
+interface SignMessageResponse {
+  signature: string;
+  signingPubKey: string;
+}
+
 interface GetNFTsResponse {
   account_nfts: AccountNFToken[];
   marker?: unknown;
@@ -87,7 +92,7 @@ export interface LedgerContextType {
   // Return transaction hash in case of success
   sendPayment: (payload: SendPaymentRequest) => Promise<string>;
   setTrustline: (payload: SetTrustlineRequest) => Promise<string>;
-  signMessage: (message: string) => string | undefined;
+  signMessage: (message: string) => SignMessageResponse | undefined;
   estimateNetworkFees: (payload: Transaction) => Promise<string>;
   getNFTs: (payload?: GetNFTRequest) => Promise<GetNFTsResponse>;
   getTransactions: () => Promise<AccountTransaction[]>;
@@ -358,7 +363,10 @@ const LedgerProvider: FC = ({ children }) => {
           throw new Error('You need to have a wallet connected to sign a message');
         } else {
           const messageHex = Buffer.from(message, 'utf8').toString('hex');
-          return sign(messageHex, wallet.wallet.privateKey);
+          return {
+            signature: sign(messageHex, wallet.wallet.privateKey),
+            signingPubKey: wallet.wallet.publicKey
+          };
         }
       } catch (e) {
         Sentry.captureException(e);


### PR DESCRIPTION
I'm currently having a hard time verifying a signature created by the GemWallet. The public wallet address  (e.g. `rHxRsPLGRV8j2RfP9vL8ByRm1ajGJDQps8`) alone isn't enough to compute the verification. As such, this PR adds a `signingPubKey` field (signer public key) to the `signMessage` response.

If there is a better way of doing this or in case you happen to have an example of verifying a signed message, I'm eager to hear it!.

I did **NOT** have a chance to properly test this PR. In case this a welcome change the PR needs thorough reviewing, possibly changes.

Additional remark:
Might be related to backwards compatibility/legacy things, but calling the result `signedMessage` seems quite confusing, when in fact a signature is being returned. I would prefer it being called `signature`.