### PR TITLE
Resolve NFT image when the URI is an ipfs to a direct image link

### DIFF
--- a/packages/extension/src/utils/NFTDataResolver.test.ts
+++ b/packages/extension/src/utils/NFTDataResolver.test.ts
@@ -4,13 +4,6 @@ import { IPFSResolverPrefix } from '@gemwallet/constants/src/xrpl/nft.constant';
 
 import { resolveNFTData } from './NFTDataResolver';
 
-const mockNFT = {
-  Flags: 0,
-  Issuer: '',
-  NFTokenTaxon: 0,
-  nft_serial: 0
-};
-
 describe('resolveNFTData', () => {
   let mockFetch: jest.SpyInstance;
 
@@ -23,7 +16,16 @@ describe('resolveNFTData', () => {
   });
 
   it('should return NFTokenID and description if URI is empty', async () => {
-    const result = await resolveNFTData({ ...mockNFT, NFTokenID: '1234' });
+    const result = await resolveNFTData(
+      {
+        NFTokenID: '1234',
+        Flags: 0,
+        Issuer: '',
+        NFTokenTaxon: 0,
+        nft_serial: 0
+      },
+      jest.fn()
+    );
     expect(result).toEqual({
       NFTokenID: '1234',
       description: 'No data'
@@ -32,11 +34,17 @@ describe('resolveNFTData', () => {
 
   it('should return NFTokenID and image URL if URL is a PNG image', async () => {
     mockFetch.mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
-    const result = await resolveNFTData({
-      ...mockNFT,
-      NFTokenID: '1234',
-      URI: convertStringToHex('https://test.com/image.png')
-    });
+    const result = await resolveNFTData(
+      {
+        NFTokenID: '1234',
+        URI: convertStringToHex('https://test.com/image.png'),
+        Flags: 0,
+        Issuer: '',
+        NFTokenTaxon: 0,
+        nft_serial: 0
+      },
+      jest.fn()
+    );
     expect(result).toEqual({
       NFTokenID: '1234',
       image: 'https://test.com/image.png'
@@ -45,11 +53,17 @@ describe('resolveNFTData', () => {
 
   it('should return NFTokenID and image URL if URL is a JPG image', async () => {
     mockFetch.mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
-    const result = await resolveNFTData({
-      ...mockNFT,
-      NFTokenID: '1234',
-      URI: convertStringToHex('https://test.com/image.jpg')
-    });
+    const result = await resolveNFTData(
+      {
+        NFTokenID: '1234',
+        URI: convertStringToHex('https://test.com/image.jpg'),
+        Flags: 0,
+        Issuer: '',
+        NFTokenTaxon: 0,
+        nft_serial: 0
+      },
+      jest.fn()
+    );
     expect(result).toEqual({
       NFTokenID: '1234',
       image: 'https://test.com/image.jpg'
@@ -61,11 +75,17 @@ describe('resolveNFTData', () => {
     (global.fetch as jest.Mock).mockResolvedValue(
       new Response(JSON.stringify({ description: 'Test JSON' }))
     );
-    const result = await resolveNFTData({
-      ...mockNFT,
-      NFTokenID: '1234',
-      URI: convertStringToHex('https://test.com/data.json')
-    });
+    const result = await resolveNFTData(
+      {
+        NFTokenID: '1234',
+        URI: convertStringToHex('https://test.com/data.json'),
+        Flags: 0,
+        Issuer: '',
+        NFTokenTaxon: 0,
+        nft_serial: 0
+      },
+      jest.fn()
+    );
     expect(result).toEqual({
       NFTokenID: '1234',
       description: 'Test JSON',
@@ -77,11 +97,17 @@ describe('resolveNFTData', () => {
     const testJsonUrl = 'https://test.com/data.json';
     (global.fetch as jest.Mock).mockRejectedValueOnce(new Error('Fetch failed'));
 
-    const result = await resolveNFTData({
-      ...mockNFT,
-      NFTokenID: '1234',
-      URI: convertStringToHex(testJsonUrl)
-    });
+    const result = await resolveNFTData(
+      {
+        NFTokenID: '1234',
+        URI: convertStringToHex(testJsonUrl),
+        Flags: 0,
+        Issuer: '',
+        NFTokenTaxon: 0,
+        nft_serial: 0
+      },
+      jest.fn()
+    );
 
     expect(result).toEqual({
       NFTokenID: '1234',
@@ -93,15 +119,21 @@ describe('resolveNFTData', () => {
     const testIpfsUrl = `${IPFSResolverPrefix}someHash`;
     (global.fetch as jest.Mock).mockRejectedValueOnce(new Error('Fetch failed'));
 
-    const result = await resolveNFTData({
-      ...mockNFT,
-      NFTokenID: '1234',
-      URI: convertStringToHex(testIpfsUrl)
-    });
+    const result = await resolveNFTData(
+      {
+        NFTokenID: '1234',
+        URI: convertStringToHex(testIpfsUrl),
+        Flags: 0,
+        Issuer: '',
+        NFTokenTaxon: 0,
+        nft_serial: 0
+      },
+      jest.fn()
+    );
 
     expect(result).toEqual({
       NFTokenID: '1234',
-      description: `ipfs://someHash`
+      description: testIpfsUrl
     });
   });
 });

--- a/packages/extension/src/utils/NFTDataResolver.ts
+++ b/packages/extension/src/utils/NFTDataResolver.ts
@@ -78,12 +78,12 @@ export const resolveNFTData = async (
         const response = await fetch(resourceURL);
         const contentType = response.headers.get('content-type');
 
-        if (contentType && contentType.includes('application/json')) {
+        if (contentType?.includes('application/json')) {
           // If it follows the XLS-24 standard, it will be automatically parsed
           return parseJSON(resourceURL, NFTokenID);
         }
 
-        if (contentType && contentType.startsWith('image/')) {
+        if (contentType?.startsWith('image/')) {
           return {
             NFTokenID,
             image: resourceURL
@@ -95,6 +95,6 @@ export const resolveNFTData = async (
   // Case 3 - Return the raw NFT attributes
   return {
     NFTokenID,
-    description: URL.replace(IPFSResolverPrefix, 'ipfs://')
+    description: URI ? convertHexToString(URI) : undefined
   };
 };

--- a/packages/extension/src/utils/NFTDataResolver.ts
+++ b/packages/extension/src/utils/NFTDataResolver.ts
@@ -74,9 +74,21 @@ export const resolveNFTData = async (
     // Case 2.2 - The URL is an IPFS hash
     if (!URL.startsWith(IPFSResolverPrefix) && !URL.startsWith('http')) {
       try {
-        await fetch(`${IPFSResolverPrefix}${URL}`);
-        // If it follows the XLS-24 standard, it will be automatically parsed
-        return parseJSON(`${IPFSResolverPrefix}${URL}`, NFTokenID);
+        const resourceURL = `${IPFSResolverPrefix}${URL}`;
+        const response = await fetch(resourceURL);
+        const contentType = response.headers.get('content-type');
+
+        if (contentType && contentType.includes('application/json')) {
+          // If it follows the XLS-24 standard, it will be automatically parsed
+          return parseJSON(resourceURL, NFTokenID);
+        }
+
+        if (contentType && contentType.startsWith('image/')) {
+          return {
+            NFTokenID,
+            image: resourceURL
+          };
+        }
       } catch (e) {}
     }
   }


### PR DESCRIPTION
To test it, modify `NFTListing.tsx` with the following code:

```
import { FC } from 'react';

import { List } from '@mui/material';
import InfiniteScroll from 'react-infinite-scroll-component';
import { convertStringToHex } from 'xrpl';

import { AccountNFTokenResponse } from '@gemwallet/constants';

import { InformationMessage } from '../../molecules';
import { NFTCard } from '../../molecules';
import { MAX_FETCHED_NFTS } from '../../pages';

export interface NFTListingProps extends AccountNFTokenResponse {
  onLoadMoreClick: () => void;
  isLoading: boolean;
}

export const NFTListing: FC<NFTListingProps> = ({ isLoading, account_nfts, onLoadMoreClick }) => {
  if (account_nfts.length === 0 && !isLoading) {
    return (
      <InformationMessage title="No NFTs to show">
        <div style={{ marginBottom: '5px' }}>There are no NFTs found in this wallet.</div>
      </InformationMessage>
    );
  }

  return (
    <InfiniteScroll
      dataLength={account_nfts.length}
      next={onLoadMoreClick}
      hasMore={account_nfts.length >= MAX_FETCHED_NFTS}
      height={450}
      loader={<h4>Loading...</h4>}
    >
      <List dense style={{ paddingTop: 0 }}>
        {account_nfts.map((NFT, index) => {
          if (index === 0) {
            NFT.NFTokenID = '00081B581189F5687DBB7516339D6CCB5593D96622AD82DFF1378E59000012D2';
            NFT.URI = convertStringToHex('QmWCjwKMCNcixHqDKcTR6zngCZFJVHtredh6SAnKzewP5C');
            NFT.Issuer = 'rpbjkoncKiv1LkPWShzZksqYPzKXmUhTW7';
          }
          return <NFTCard key={NFT.NFTokenID} NFT={NFT} />;
        })}
      </List>
    </InfiniteScroll>
  );
};
```