### PR TITLE
Disable login after too many wrong password attempts

### DIFF
--- a/packages/extension/src/components/pages/Login/Login.tsx
+++ b/packages/extension/src/components/pages/Login/Login.tsx
@@ -67,7 +67,7 @@ import {
 } from '../../../utils/storageChromeLocal';
 import { Logo } from '../../atoms/Logo';
 
-const maxAttempts = 5;
+const MAX_ATTEMPTS = 5;
 const DELAY_RETRY_MINS = 15;
 
 export const Login: FC = () => {

--- a/packages/extension/src/components/pages/Login/Login.tsx
+++ b/packages/extension/src/components/pages/Login/Login.tsx
@@ -67,12 +67,13 @@ import {
 } from '../../../utils/storageChromeLocal';
 import { Logo } from '../../atoms/Logo';
 
+const maxAttempts = 5;
+
 export const Login: FC = () => {
   const [passwordError, setPasswordError] = useState('');
   const [rememberSession, setRememberSession] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
   const [disableLogin, setDisableLogin] = useState(false);
-  const maxAttempts = 5;
   const [currentAttempts, setCurrentAttempts] = useState(0);
   const navigate = useNavigate();
   const { search } = useLocation();
@@ -141,8 +142,8 @@ export const Login: FC = () => {
     const loadTimerData = async () => {
       const storedTimerData = await loadFromChromeLocalStorage('disabledLoginTimer');
       if (storedTimerData !== null) {
-        const expireDate = storedTimerData;
-        if (expireDate > Date.now()) {
+        const expirationDate = storedTimerData;
+        if (expirationDate > Date.now()) {
           setDisableLogin(true);
         } else {
           setDisableLogin(false);
@@ -177,9 +178,9 @@ export const Login: FC = () => {
       }
     } else {
       if (currentAttempts >= maxAttempts) {
-        let TIMESTAMP = Date.now();
+        const TIMESTAMP = Date.now() + 1000 * 60 * 15;
         setDisableLogin(true);
-        saveInChromeLocalStorage('disabledLoginTimer', TIMESTAMP + 1000 * 60 * 15);
+        saveInChromeLocalStorage('disabledLoginTimer', TIMESTAMP);
         setPasswordError('Please try again in 15 min');
       } else {
         setCurrentAttempts((currentAttempts) => currentAttempts + 1);

--- a/packages/extension/src/components/pages/Login/Login.tsx
+++ b/packages/extension/src/components/pages/Login/Login.tsx
@@ -178,7 +178,7 @@ export const Login: FC = () => {
           });
       }
     } else {
-      if (currentAttempts >= maxAttempts - 1) {
+      if (currentAttempts >= MAX_ATTEMPTS - 1) {
         const TIMESTAMP = Date.now() + 1000 * 60 * DELAY_RETRY_MINS;
         setDisableLogin(true);
         saveInChromeLocalStorage('disabledLoginTimer', TIMESTAMP);

--- a/packages/extension/src/components/pages/Login/Login.tsx
+++ b/packages/extension/src/components/pages/Login/Login.tsx
@@ -133,6 +133,22 @@ export const Login: FC = () => {
     loadRememberSession();
   }, []);
 
+  useEffect(() => {
+    const data = window.localStorage.getItem('loginDisabled');
+    if (data !== null) {
+      console.log('current date:' + Date.now());
+      const expireDate = JSON.parse(data).expiresOn;
+      console.log('expireDate' + expireDate);
+      if (expireDate > Date.now()) {
+        console.log('hello login disable');
+        setDisableLogin(true);
+      } else {
+        console.log('hello login ok ');
+        setDisableLogin(false);
+      }
+    }
+  }, []);
+
   const handleUnlock = useCallback(() => {
     const passwordValue = passwordRef.current?.value;
     if (passwordValue && signIn(passwordValue, rememberSession)) {
@@ -158,7 +174,15 @@ export const Login: FC = () => {
       }
     } else {
       if (currentAttempts >= maxAttempts) {
+        let TIMESTAMP = Date.now();
         setDisableLogin(true);
+        window.localStorage.setItem(
+          'loginDisabled',
+          JSON.stringify({
+            value: true,
+            expiresOn: TIMESTAMP + 1000 * 60 * 15
+          })
+        );
         setPasswordError('Please try again in 15 min');
       } else {
         setCurrentAttempts((currentAttempts) => currentAttempts + 1);

--- a/packages/extension/src/components/pages/Login/Login.tsx
+++ b/packages/extension/src/components/pages/Login/Login.tsx
@@ -68,6 +68,7 @@ import {
 import { Logo } from '../../atoms/Logo';
 
 const maxAttempts = 5;
+const DELAY_RETRY_MINS = 15;
 
 export const Login: FC = () => {
   const [passwordError, setPasswordError] = useState('');
@@ -142,9 +143,9 @@ export const Login: FC = () => {
     const loadTimerData = async () => {
       const storedTimerData = await loadFromChromeLocalStorage('disabledLoginTimer');
       if (storedTimerData !== null) {
-        const expirationDate = storedTimerData;
-        if (expirationDate > Date.now()) {
+        if (storedTimerData > Date.now()) {
           setDisableLogin(true);
+          setPasswordError('Too many attempts, please try again later');
         } else {
           setDisableLogin(false);
         }
@@ -177,11 +178,11 @@ export const Login: FC = () => {
           });
       }
     } else {
-      if (currentAttempts >= maxAttempts) {
-        const TIMESTAMP = Date.now() + 1000 * 60 * 15;
+      if (currentAttempts >= maxAttempts - 1) {
+        const TIMESTAMP = Date.now() + 1000 * 60 * DELAY_RETRY_MINS;
         setDisableLogin(true);
         saveInChromeLocalStorage('disabledLoginTimer', TIMESTAMP);
-        setPasswordError('Please try again in 15 min');
+        setPasswordError(`Please try again in ${DELAY_RETRY_MINS} mins`);
       } else {
         setCurrentAttempts((currentAttempts) => currentAttempts + 1);
         setPasswordError('Incorrect password');

--- a/packages/extension/src/components/pages/Login/Login.tsx
+++ b/packages/extension/src/components/pages/Login/Login.tsx
@@ -61,6 +61,10 @@ import { useWallet } from '../../../contexts';
 import { useKeyUp } from '../../../hooks/useKeyUp';
 import { loadData } from '../../../utils';
 import { loadRememberSessionState, saveRememberSessionState } from '../../../utils/login';
+import {
+  loadFromChromeLocalStorage,
+  saveInChromeLocalStorage
+} from '../../../utils/storageChromeLocal';
 import { Logo } from '../../atoms/Logo';
 
 export const Login: FC = () => {
@@ -134,19 +138,18 @@ export const Login: FC = () => {
   }, []);
 
   useEffect(() => {
-    const data = window.localStorage.getItem('loginDisabled');
-    if (data !== null) {
-      console.log('current date:' + Date.now());
-      const expireDate = JSON.parse(data).expiresOn;
-      console.log('expireDate' + expireDate);
-      if (expireDate > Date.now()) {
-        console.log('hello login disable');
-        setDisableLogin(true);
-      } else {
-        console.log('hello login ok ');
-        setDisableLogin(false);
+    const loadTimerData = async () => {
+      const storedTimerData = await loadFromChromeLocalStorage('disabledLoginTimer');
+      if (storedTimerData !== null) {
+        const expireDate = storedTimerData;
+        if (expireDate > Date.now()) {
+          setDisableLogin(true);
+        } else {
+          setDisableLogin(false);
+        }
       }
-    }
+    };
+    loadTimerData();
   }, []);
 
   const handleUnlock = useCallback(() => {
@@ -176,17 +179,10 @@ export const Login: FC = () => {
       if (currentAttempts >= maxAttempts) {
         let TIMESTAMP = Date.now();
         setDisableLogin(true);
-        window.localStorage.setItem(
-          'loginDisabled',
-          JSON.stringify({
-            value: true,
-            expiresOn: TIMESTAMP + 1000 * 60 * 15
-          })
-        );
+        saveInChromeLocalStorage('disabledLoginTimer', TIMESTAMP + 1000 * 60 * 15);
         setPasswordError('Please try again in 15 min');
       } else {
         setCurrentAttempts((currentAttempts) => currentAttempts + 1);
-        console.log(currentAttempts);
         setPasswordError('Incorrect password');
       }
     }

--- a/packages/extension/src/components/pages/Login/Login.tsx
+++ b/packages/extension/src/components/pages/Login/Login.tsx
@@ -67,6 +67,9 @@ export const Login: FC = () => {
   const [passwordError, setPasswordError] = useState('');
   const [rememberSession, setRememberSession] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
+  const [disableLogin, setDisableLogin] = useState(false);
+  const maxAttempts = 5;
+  const [currentAttempts, setCurrentAttempts] = useState(0);
   const navigate = useNavigate();
   const { search } = useLocation();
   const { signIn, wallets, selectedWallet } = useWallet();
@@ -154,9 +157,16 @@ export const Login: FC = () => {
           });
       }
     } else {
-      setPasswordError('Incorrect password');
+      if (currentAttempts >= maxAttempts) {
+        setDisableLogin(true);
+        setPasswordError('Please try again in 15 min');
+      } else {
+        setCurrentAttempts((currentAttempts) => currentAttempts + 1);
+        console.log(currentAttempts);
+        setPasswordError('Incorrect password');
+      }
     }
-  }, [signIn, rememberSession, navigateToPath]);
+  }, [signIn, rememberSession, navigateToPath, currentAttempts]);
 
   // Handle Login step button by pressing 'Enter'
   useKeyUp('Enter', handleUnlock);
@@ -208,6 +218,7 @@ export const Login: FC = () => {
           id="password"
           name="password"
           label="Password"
+          disabled={disableLogin}
           inputRef={passwordRef}
           error={!!passwordError}
           onChange={handleTextFieldChange}
@@ -243,7 +254,7 @@ export const Login: FC = () => {
           }
           style={{ marginTop: '5px' }}
         />
-        <Button variant="contained" onClick={handleUnlock}>
+        <Button variant="contained" onClick={handleUnlock} disabled={disableLogin}>
           Unlock
         </Button>
         <Typography


### PR DESCRIPTION
- currently disable the login after 5 password attempts.
- disabled on 15 min, even when refreshing or exiting the extension. Data stored on chrome local storage.