### PR TITLE
Detect wrong NetworkID in Transaction views

### DIFF
--- a/packages/constants/src/network/network.constant.ts
+++ b/packages/constants/src/network/network.constant.ts
@@ -37,6 +37,7 @@ export interface NetworkNode {
   server: string;
   nodes?: string[];
   description: string;
+  networkID?: number;
 }
 
 interface NetworkConfigXRPL {
@@ -64,7 +65,8 @@ export const NETWORK: ChainConfig = {
       name: XRPLNetwork.MAINNET,
       server: MAINNET_NODES[0],
       nodes: MAINNET_NODES,
-      description: 'Main network using the production version of the XRP Ledger.'
+      description: 'Main network using the production version of the XRP Ledger.',
+      networkID: 0
     },
     [XRPLNetwork.TESTNET]: {
       chain: Chain.XRPL,
@@ -72,7 +74,8 @@ export const NETWORK: ChainConfig = {
       server: TESTNET_NODES[0],
       nodes: TESTNET_NODES,
       description:
-        'Acts as a testing network, without impacting production users and risking real money.'
+        'Acts as a testing network, without impacting production users and risking real money.',
+      networkID: 1
     },
     [XRPLNetwork.DEVNET]: {
       chain: Chain.XRPL,
@@ -94,14 +97,16 @@ export const NETWORK: ChainConfig = {
       name: XahauNetwork.XAHAU_MAINNET,
       server: XAHAU_MAINNET_NODES[0],
       nodes: XAHAU_MAINNET_NODES,
-      description: 'Mainnet for the Xahau blockchain.'
+      description: 'Mainnet for the Xahau blockchain.',
+      networkID: 21337
     },
     [XahauNetwork.XAHAU_TESTNET]: {
       chain: Chain.XAHAU,
       name: XahauNetwork.XAHAU_TESTNET,
       server: XAHAU_TESTNET_NODES[0],
       nodes: XAHAU_TESTNET_NODES,
-      description: 'Testnet for the Xahau blockchain.'
+      description: 'Testnet for the Xahau blockchain.',
+      networkID: 21338
     },
     [XahauNetwork.CUSTOM]: {
       chain: Chain.XAHAU,
@@ -132,3 +137,19 @@ export function getNetwork(chain: Chain, network: Network): NetworkNode {
 
   throw new Error(`Network ${network} is not valid for chain ${chain}`);
 }
+
+export const getNetworkByNetworkID = (networkID: number): NetworkNode => {
+  // Hardcoded for performance reasons
+  switch (networkID) {
+    case 0:
+      return NETWORK[Chain.XRPL][XRPLNetwork.MAINNET];
+    case 1:
+      return NETWORK[Chain.XRPL][XRPLNetwork.TESTNET];
+    case 21337:
+      return NETWORK[Chain.XAHAU][XahauNetwork.XAHAU_MAINNET];
+    case 21338:
+      return NETWORK[Chain.XAHAU][XahauNetwork.XAHAU_TESTNET];
+    default:
+      throw new Error(`Network ID ${networkID} is not valid`);
+  }
+};

--- a/packages/extension/src/components/organisms/TransactionDetails/WrongNetworkIDModal/WrongNetworkIDModal.tsx
+++ b/packages/extension/src/components/organisms/TransactionDetails/WrongNetworkIDModal/WrongNetworkIDModal.tsx
@@ -1,0 +1,112 @@
+import { FC, useCallback, useState } from 'react';
+
+import {
+  Dialog,
+  DialogActions,
+  Button,
+  DialogTitle,
+  DialogContent,
+  DialogContentText
+} from '@mui/material';
+
+import { NetworkNode } from '@gemwallet/constants';
+
+import { useNetwork } from '../../../../contexts';
+
+export interface WrongNetworkIDModalProps {
+  open: boolean;
+  onClose: () => void;
+  expectedNetwork: NetworkNode | null;
+  currentNetwork: NetworkNode;
+  setIsLoading: (_: boolean) => void;
+}
+
+export const WrongNetworkIDModal: FC<WrongNetworkIDModalProps> = ({
+  open,
+  onClose,
+  expectedNetwork,
+  currentNetwork,
+  setIsLoading
+}) => {
+  const { switchNetwork } = useNetwork();
+  const [showConfirmation, setShowConfirmation] = useState(false);
+
+  const displayNetwork = useCallback((network: NetworkNode) => {
+    return `${network.chain} ${network.name} (Network ID: ${network.networkID})`;
+  }, []);
+
+  const onApprove = useCallback(async () => {
+    setIsLoading(true);
+    if (expectedNetwork?.networkID && expectedNetwork?.networkID !== currentNetwork.networkID) {
+      const newChain =
+        expectedNetwork?.chain && expectedNetwork?.chain !== currentNetwork.chain
+          ? expectedNetwork.chain
+          : undefined;
+      await switchNetwork({ network: expectedNetwork.name, chain: newChain });
+    }
+
+    setShowConfirmation(true);
+    setIsLoading(false);
+  }, [
+    currentNetwork.chain,
+    currentNetwork.networkID,
+    expectedNetwork?.chain,
+    expectedNetwork?.name,
+    expectedNetwork?.networkID,
+    setIsLoading,
+    switchNetwork
+  ]);
+
+  if (!expectedNetwork) {
+    return null;
+  }
+
+  const InitialContent = () => {
+    return (
+      <>
+        <DialogTitle>Wrong Network detected</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            You are currently connected to <b>{displayNetwork(currentNetwork)}</b>, but the
+            transaction is intended for <b>{displayNetwork(expectedNetwork)}</b>.
+          </DialogContentText>
+          <DialogContentText style={{ paddingTop: '16px' }}>
+            Do you want to switch to <b>{displayNetwork(expectedNetwork)}</b>?
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={onClose} color="primary">
+            No
+          </Button>
+          <Button onClick={onApprove} color="primary">
+            Yes
+          </Button>
+        </DialogActions>
+      </>
+    );
+  };
+
+  const ConfirmationContent = () => {
+    return (
+      <>
+        <DialogTitle>Network switched</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            You are now connected to ${displayNetwork(expectedNetwork)}.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={onClose} color="primary">
+            OK
+          </Button>
+        </DialogActions>
+      </>
+    );
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} scroll="paper">
+      {showConfirmation ? <ConfirmationContent /> : <InitialContent />}
+    </Dialog>
+  );
+};

--- a/packages/extension/src/components/organisms/TransactionDetails/WrongNetworkIDModal/index.ts
+++ b/packages/extension/src/components/organisms/TransactionDetails/WrongNetworkIDModal/index.ts
@@ -1,0 +1,1 @@
+export * from './WrongNetworkIDModal';

--- a/packages/extension/src/contexts/NetworkContext/NetworkContext.tsx
+++ b/packages/extension/src/contexts/NetworkContext/NetworkContext.tsx
@@ -23,8 +23,9 @@ const DEFAULT_NETWORK_NAME = 'Loading...';
 
 interface ContextType {
   reconnectToNetwork: () => Promise<void>;
-  switchNetwork: (param: {
+  switchNetwork: (params: {
     network: Network;
+    chain?: Chain;
     customNetworkName?: string;
     customNetworkServer?: string;
   }) => Promise<void>;

--- a/packages/extension/src/hooks/useFees/useFees.test.ts
+++ b/packages/extension/src/hooks/useFees/useFees.test.ts
@@ -18,7 +18,12 @@ jest.mock('../../contexts', () => {
       })
     }),
     useNetwork: () => ({
-      client: { getXrpBalance: mockGetXrpBalance }
+      client: {
+        getXrpBalance: mockGetXrpBalance,
+        connection: {
+          getUrl: () => 'wss://s.altnet.rippletest.net:51233'
+        }
+      }
     }),
     useServer: () => ({
       serverInfo: {

--- a/packages/extension/src/hooks/useTransactionStatus/useTransactionStatus.tsx
+++ b/packages/extension/src/hooks/useTransactionStatus/useTransactionStatus.tsx
@@ -3,7 +3,6 @@ import { useCallback, useMemo, useState } from 'react';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import DoneIcon from '@mui/icons-material/Done';
 import { Button, Container, IconButton, Typography } from '@mui/material';
-import * as Sentry from '@sentry/react';
 import copyToClipboard from 'copy-to-clipboard';
 
 import { Network } from '@gemwallet/constants';
@@ -134,15 +133,6 @@ export const useTransactionStatus = ({
           />
         );
       }
-      Sentry.captureException('Transaction failed - errorFees: ' + errorFees);
-      return (
-        <AsyncTransaction
-          title="Error"
-          subtitle={errorFees}
-          transaction={TransactionStatus.Rejected}
-          {...(onClick && { onClick })}
-        />
-      );
     }
 
     if (!difference) {


### PR DESCRIPTION
How to test:
1/ Add a NetworkID in `packages/api/templates/index.html`, e.g.:
```
  function handleMintNFT() {
    GemWalletApi.isInstalled()
      .then(({ result }) => {
        if (result.isInstalled) {
          const transaction = {
            URI: '4d696e746564207468726f7567682047656d57616c6c657421',
            flags: {
              tfOnlyXRP: true,
              tfTransferable: true
            },
            // fee: '199',
            transferFee: 3000, // 3%,
            NFTokenTaxon: 0,
            networkID: 21338,
            memos: [
              {
                memo: {
                  memoType: '4465736372697074696f6e',
                  memoData: '54657374206d656d6f'
                }
              }
            ]
          };

          GemWalletApi.mintNFT(transaction)
            .then((res) => {
              console.log('Received response: ', res);
            })
            .catch((e) => {
              console.error('Cannot proceed the transaction: ', e);
            });
        }
      })
      .catch((e) => {
        console.error('GemWallet is not connected: ', e);
      });
  }
```

21338 for Xahau Testnet

2/ Open GemWallet, set the chain to XRPL.

3/ Try the transaction: a modal will appear asking to switch network