### PR TITLE
Add PaymentChannelAuthorize transaction type

### DIFF
--- a/packages/extension/src/components/organisms/TransactionListing/format.util.ts
+++ b/packages/extension/src/components/organisms/TransactionListing/format.util.ts
@@ -46,6 +46,7 @@ const transactionMappers: Record<TransactionTypes, TransactionFormatter> = {
   [TransactionTypes.CheckCash]: () => 'Cash check',
   [TransactionTypes.CheckCancel]: () => 'Cancel check',
   [TransactionTypes.TicketCreate]: () => 'Create ticket',
+  [TransactionTypes.PaymentChannelAuthorize]: () => 'Authorize payment channel',
   [TransactionTypes.PaymentChannelCreate]: () => 'Create payment channel',
   [TransactionTypes.PaymentChannelClaim]: () => 'Claim payment channel',
   [TransactionTypes.PaymentChannelFund]: () => 'Fund payment channel',

--- a/packages/extension/src/types/transaction.types.ts
+++ b/packages/extension/src/types/transaction.types.ts
@@ -27,6 +27,7 @@ export enum TransactionTypes {
   OfferCancel = 'OfferCancel',
   OfferCreate = 'OfferCreate',
   Payment = 'Payment',
+  PaymentChannelAuthorize = 'PaymentChannelAuthorize',
   PaymentChannelClaim = 'PaymentChannelClaim',
   PaymentChannelCreate = 'PaymentChannelCreate',
   PaymentChannelFund = 'PaymentChannelFund',


### PR DESCRIPTION
This PR adds the PaymentChannelAuthorize transaction type.

With this feature, Dhali should be able to use GemWallet within our API monetization gateway