### PR TITLE
feat: Add MPToken API support for dApps

### DIFF
--- a/packages/api/src/authorizeMPToken/authorizeMPToken.ts
+++ b/packages/api/src/authorizeMPToken/authorizeMPToken.ts
@@ -1,0 +1,53 @@
+import {
+  AuthorizeMPTokenRequest,
+  AuthorizeMPTokenResponse,
+  GEM_WALLET,
+  RequestAuthorizeMPTokenMessage,
+  ResponseType
+} from '@gemwallet/constants';
+
+import { deserializeError } from '../helpers/errors';
+import { sendMessageToContentScript } from '../helpers/extensionMessaging';
+
+export const authorizeMPToken = async (
+  payload: AuthorizeMPTokenRequest
+): Promise<AuthorizeMPTokenResponse> => {
+  /* response:
+   * if the transaction succeeds:
+   * - type: 'response'
+   * - result:
+   *    - hash: hash of the transaction
+   *
+   * if the user rejects the transaction:
+   * - type: 'reject'
+   * - result: undefined
+   *
+   * if the transaction fails:
+   * - throw an error
+   */
+  let response: AuthorizeMPTokenResponse = {
+    type: ResponseType.Reject,
+    result: undefined
+  };
+
+  try {
+    const message: RequestAuthorizeMPTokenMessage = {
+      app: GEM_WALLET,
+      type: 'REQUEST_AUTHORIZE_MPTOKEN/V3',
+      payload
+    };
+    const { result, error } = await sendMessageToContentScript(message);
+    const parsedError = error ? deserializeError(error) : undefined;
+    if (parsedError) {
+      throw parsedError;
+    }
+
+    if (result) {
+      response.type = ResponseType.Response;
+      response.result = result;
+    }
+  } catch (e) {
+    throw e;
+  }
+  return response;
+};

--- a/packages/api/src/authorizeMPToken/index.ts
+++ b/packages/api/src/authorizeMPToken/index.ts
@@ -1,0 +1,1 @@
+export * from './authorizeMPToken';

--- a/packages/api/src/createMPTokenIssuance/createMPTokenIssuance.ts
+++ b/packages/api/src/createMPTokenIssuance/createMPTokenIssuance.ts
@@ -1,0 +1,53 @@
+import {
+  CreateMPTokenIssuanceRequest,
+  CreateMPTokenIssuanceResponse,
+  GEM_WALLET,
+  RequestCreateMPTokenIssuanceMessage,
+  ResponseType
+} from '@gemwallet/constants';
+
+import { deserializeError } from '../helpers/errors';
+import { sendMessageToContentScript } from '../helpers/extensionMessaging';
+
+export const createMPTokenIssuance = async (
+  payload: CreateMPTokenIssuanceRequest
+): Promise<CreateMPTokenIssuanceResponse> => {
+  /* response:
+   * if the transaction succeeds:
+   * - type: 'response'
+   * - result:
+   *    - hash: hash of the transaction
+   *
+   * if the user rejects the transaction:
+   * - type: 'reject'
+   * - result: undefined
+   *
+   * if the transaction fails:
+   * - throw an error
+   */
+  let response: CreateMPTokenIssuanceResponse = {
+    type: ResponseType.Reject,
+    result: undefined
+  };
+
+  try {
+    const message: RequestCreateMPTokenIssuanceMessage = {
+      app: GEM_WALLET,
+      type: 'REQUEST_CREATE_MPTOKEN_ISSUANCE/V3',
+      payload
+    };
+    const { result, error } = await sendMessageToContentScript(message);
+    const parsedError = error ? deserializeError(error) : undefined;
+    if (parsedError) {
+      throw parsedError;
+    }
+
+    if (result) {
+      response.type = ResponseType.Response;
+      response.result = result;
+    }
+  } catch (e) {
+    throw e;
+  }
+  return response;
+};

--- a/packages/api/src/createMPTokenIssuance/index.ts
+++ b/packages/api/src/createMPTokenIssuance/index.ts
@@ -1,0 +1,1 @@
+export * from './createMPTokenIssuance';

--- a/packages/api/src/destroyMPTokenIssuance/destroyMPTokenIssuance.ts
+++ b/packages/api/src/destroyMPTokenIssuance/destroyMPTokenIssuance.ts
@@ -1,0 +1,53 @@
+import {
+  DestroyMPTokenIssuanceRequest,
+  DestroyMPTokenIssuanceResponse,
+  GEM_WALLET,
+  RequestDestroyMPTokenIssuanceMessage,
+  ResponseType
+} from '@gemwallet/constants';
+
+import { deserializeError } from '../helpers/errors';
+import { sendMessageToContentScript } from '../helpers/extensionMessaging';
+
+export const destroyMPTokenIssuance = async (
+  payload: DestroyMPTokenIssuanceRequest
+): Promise<DestroyMPTokenIssuanceResponse> => {
+  /* response:
+   * if the transaction succeeds:
+   * - type: 'response'
+   * - result:
+   *    - hash: hash of the transaction
+   *
+   * if the user rejects the transaction:
+   * - type: 'reject'
+   * - result: undefined
+   *
+   * if the transaction fails:
+   * - throw an error
+   */
+  let response: DestroyMPTokenIssuanceResponse = {
+    type: ResponseType.Reject,
+    result: undefined
+  };
+
+  try {
+    const message: RequestDestroyMPTokenIssuanceMessage = {
+      app: GEM_WALLET,
+      type: 'REQUEST_DESTROY_MPTOKEN_ISSUANCE/V3',
+      payload
+    };
+    const { result, error } = await sendMessageToContentScript(message);
+    const parsedError = error ? deserializeError(error) : undefined;
+    if (parsedError) {
+      throw parsedError;
+    }
+
+    if (result) {
+      response.type = ResponseType.Response;
+      response.result = result;
+    }
+  } catch (e) {
+    throw e;
+  }
+  return response;
+};

--- a/packages/api/src/destroyMPTokenIssuance/index.ts
+++ b/packages/api/src/destroyMPTokenIssuance/index.ts
@@ -1,0 +1,1 @@
+export * from './destroyMPTokenIssuance';

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,9 +1,12 @@
 export * from './acceptNFTOffer';
+export * from './authorizeMPToken';
 export * from './burnNFT';
 export * from './cancelNFTOffer';
 export * from './cancelOffer';
+export * from './createMPTokenIssuance';
 export * from './createNFTOffer';
 export * from './createOffer';
+export * from './destroyMPTokenIssuance';
 export * from './on';
 export * from './getAddress';
 export * from './getNetwork';
@@ -14,6 +17,7 @@ export * from './mintNFT';
 export * from './sendPayment';
 export * from './setAccount';
 export * from './setHook';
+export * from './setMPTokenIssuance';
 export * from './setRegularKey';
 export * from './setTrustline';
 export * from './signMessage';
@@ -36,17 +40,21 @@ export type {
 // API request types
 export type {
   AcceptNFTOfferRequest,
+  AuthorizeMPTokenRequest,
   BurnNFTRequest,
   CancelNFTOfferRequest,
   CancelOfferRequest,
+  CreateMPTokenIssuanceRequest,
   CreateNFTOfferRequest,
   CreateOfferRequest,
+  DestroyMPTokenIssuanceRequest,
   GetNetworkRequest,
   GetNFTRequest,
   MintNFTRequest,
   SendPaymentRequest,
   SetAccountRequest,
   SetHookRequest,
+  SetMPTokenIssuanceRequest,
   SetRegularKeyRequest,
   SetTrustlineRequest,
   SignMessageRequest,
@@ -58,11 +66,14 @@ export type {
 // API response types
 export type {
   AcceptNFTOfferResponse,
+  AuthorizeMPTokenResponse,
   BurnNFTResponse,
   CancelNFTOfferResponse,
   CancelOfferResponse,
+  CreateMPTokenIssuanceResponse,
   CreateNFTOfferResponse,
   CreateOfferResponse,
+  DestroyMPTokenIssuanceResponse,
   GetAddressResponse,
   GetNetworkResponse,
   GetNFTResponse,
@@ -72,6 +83,7 @@ export type {
   SendPaymentResponse,
   SetAccountResponse,
   SetHookResponse,
+  SetMPTokenIssuanceResponse,
   SetRegularKeyResponse,
   SetTrustlineResponse,
   SignMessageResponse,

--- a/packages/api/src/setMPTokenIssuance/index.ts
+++ b/packages/api/src/setMPTokenIssuance/index.ts
@@ -1,0 +1,1 @@
+export * from './setMPTokenIssuance';

--- a/packages/api/src/setMPTokenIssuance/setMPTokenIssuance.ts
+++ b/packages/api/src/setMPTokenIssuance/setMPTokenIssuance.ts
@@ -1,0 +1,53 @@
+import {
+  GEM_WALLET,
+  RequestSetMPTokenIssuanceMessage,
+  ResponseType,
+  SetMPTokenIssuanceRequest,
+  SetMPTokenIssuanceResponse
+} from '@gemwallet/constants';
+
+import { deserializeError } from '../helpers/errors';
+import { sendMessageToContentScript } from '../helpers/extensionMessaging';
+
+export const setMPTokenIssuance = async (
+  payload: SetMPTokenIssuanceRequest
+): Promise<SetMPTokenIssuanceResponse> => {
+  /* response:
+   * if the transaction succeeds:
+   * - type: 'response'
+   * - result:
+   *    - hash: hash of the transaction
+   *
+   * if the user rejects the transaction:
+   * - type: 'reject'
+   * - result: undefined
+   *
+   * if the transaction fails:
+   * - throw an error
+   */
+  let response: SetMPTokenIssuanceResponse = {
+    type: ResponseType.Reject,
+    result: undefined
+  };
+
+  try {
+    const message: RequestSetMPTokenIssuanceMessage = {
+      app: GEM_WALLET,
+      type: 'REQUEST_SET_MPTOKEN_ISSUANCE/V3',
+      payload
+    };
+    const { result, error } = await sendMessageToContentScript(message);
+    const parsedError = error ? deserializeError(error) : undefined;
+    if (parsedError) {
+      throw parsedError;
+    }
+
+    if (result) {
+      response.type = ResponseType.Response;
+      response.result = result;
+    }
+  } catch (e) {
+    throw e;
+  }
+  return response;
+};

--- a/packages/constants/src/message/message.types.ts
+++ b/packages/constants/src/message/message.types.ts
@@ -2,16 +2,22 @@ import { GEM_WALLET } from '../global/global.constant';
 import {
   AcceptNFTOfferResponse,
   AcceptNFTOfferRequest,
+  AuthorizeMPTokenRequest,
+  AuthorizeMPTokenResponse,
   BurnNFTRequest,
   BurnNFTResponse,
   CancelNFTOfferRequest,
   CancelNFTOfferResponse,
   CancelOfferRequest,
   CancelOfferResponse,
+  CreateMPTokenIssuanceRequest,
+  CreateMPTokenIssuanceResponse,
   CreateNFTOfferRequest,
   CreateNFTOfferResponse,
   CreateOfferRequest,
   CreateOfferResponse,
+  DestroyMPTokenIssuanceRequest,
+  DestroyMPTokenIssuanceResponse,
   EventLoginResponse,
   EventLogoutResponse,
   EventNetworkChangedResponse,
@@ -37,6 +43,8 @@ import {
   SetAccountRequest,
   SetHookResponse,
   SetHookRequest,
+  SetMPTokenIssuanceRequest,
+  SetMPTokenIssuanceResponse,
   SetRegularKeyResponse,
   SetRegularKeyRequest,
   SetTrustlineResponse,
@@ -88,6 +96,10 @@ export type RequestMessage =
   | 'REQUEST_SIGN_TRANSACTION/V3'
   | 'REQUEST_SUBMIT_TRANSACTION/V3'
   | 'REQUEST_SUBMIT_BULK_TRANSACTIONS/V3'
+  | 'REQUEST_AUTHORIZE_MPTOKEN/V3'
+  | 'REQUEST_CREATE_MPTOKEN_ISSUANCE/V3'
+  | 'REQUEST_DESTROY_MPTOKEN_ISSUANCE/V3'
+  | 'REQUEST_SET_MPTOKEN_ISSUANCE/V3'
   | 'SEND_PAYMENT';
 
 export type ReceiveMessage =
@@ -117,7 +129,11 @@ export type ReceiveMessage =
   | 'RECEIVE_SIGN_MESSAGE/V3'
   | 'RECEIVE_SIGN_TRANSACTION/V3'
   | 'RECEIVE_SUBMIT_TRANSACTION/V3'
-  | 'RECEIVE_SUBMIT_BULK_TRANSACTIONS/V3';
+  | 'RECEIVE_SUBMIT_BULK_TRANSACTIONS/V3'
+  | 'RECEIVE_AUTHORIZE_MPTOKEN/V3'
+  | 'RECEIVE_CREATE_MPTOKEN_ISSUANCE/V3'
+  | 'RECEIVE_DESTROY_MPTOKEN_ISSUANCE/V3'
+  | 'RECEIVE_SET_MPTOKEN_ISSUANCE/V3';
 
 export type EventMessage =
   | 'EVENT_NETWORK_CHANGED'
@@ -288,6 +304,31 @@ export interface RequestSetHookMessage {
   payload: SetHookRequest;
 }
 
+// MPToken Request Messages
+export interface RequestAuthorizeMPTokenMessage {
+  app: typeof GEM_WALLET;
+  type: 'REQUEST_AUTHORIZE_MPTOKEN/V3';
+  payload: AuthorizeMPTokenRequest;
+}
+
+export interface RequestCreateMPTokenIssuanceMessage {
+  app: typeof GEM_WALLET;
+  type: 'REQUEST_CREATE_MPTOKEN_ISSUANCE/V3';
+  payload: CreateMPTokenIssuanceRequest;
+}
+
+export interface RequestDestroyMPTokenIssuanceMessage {
+  app: typeof GEM_WALLET;
+  type: 'REQUEST_DESTROY_MPTOKEN_ISSUANCE/V3';
+  payload: DestroyMPTokenIssuanceRequest;
+}
+
+export interface RequestSetMPTokenIssuanceMessage {
+  app: typeof GEM_WALLET;
+  type: 'REQUEST_SET_MPTOKEN_ISSUANCE/V3';
+  payload: SetMPTokenIssuanceRequest;
+}
+
 // Internal
 export interface InternalRequestPasswordMessage {
   app: typeof GEM_WALLET;
@@ -352,6 +393,14 @@ export type SetRegularKeyMessagingResponse = MessagingResponse & SetRegularKeyRe
 export type SetTrustlineMessagingResponse = MessagingResponse & SetTrustlineResponse;
 export type SetTrustlineMessagingResponseDeprecated = MessagingResponse &
   SetTrustlineResponseDeprecated;
+
+// MPToken Messaging Responses
+export type AuthorizeMPTokenMessagingResponse = MessagingResponse & AuthorizeMPTokenResponse;
+export type CreateMPTokenIssuanceMessagingResponse = MessagingResponse &
+  CreateMPTokenIssuanceResponse;
+export type DestroyMPTokenIssuanceMessagingResponse = MessagingResponse &
+  DestroyMPTokenIssuanceResponse;
+export type SetMPTokenIssuanceMessagingResponse = MessagingResponse & SetMPTokenIssuanceResponse;
 
 // Internal
 export type PasswordInternalMessagingResponse = InternalMessagingResponse &
@@ -528,6 +577,31 @@ export interface ReceiveSetHookContentMessage {
   payload: SetHookMessagingResponse;
 }
 
+// MPToken Content Messages
+export interface ReceiveAuthorizeMPTokenContentMessage {
+  app: typeof GEM_WALLET;
+  type: 'RECEIVE_AUTHORIZE_MPTOKEN/V3';
+  payload: AuthorizeMPTokenMessagingResponse;
+}
+
+export interface ReceiveCreateMPTokenIssuanceContentMessage {
+  app: typeof GEM_WALLET;
+  type: 'RECEIVE_CREATE_MPTOKEN_ISSUANCE/V3';
+  payload: CreateMPTokenIssuanceMessagingResponse;
+}
+
+export interface ReceiveDestroyMPTokenIssuanceContentMessage {
+  app: typeof GEM_WALLET;
+  type: 'RECEIVE_DESTROY_MPTOKEN_ISSUANCE/V3';
+  payload: DestroyMPTokenIssuanceMessagingResponse;
+}
+
+export interface ReceiveSetMPTokenIssuanceContentMessage {
+  app: typeof GEM_WALLET;
+  type: 'RECEIVE_SET_MPTOKEN_ISSUANCE/V3';
+  payload: SetMPTokenIssuanceMessagingResponse;
+}
+
 // Internal
 export interface InternalReceivePasswordContentMessage {
   app: typeof GEM_WALLET;
@@ -664,6 +738,19 @@ export type ReceiveSubmitBulkTransactionsBackgroundMessage =
 export type ReceiveSetHookBackgroundMessage = ReceiveSetHookContentMessage &
   BackgroundMessagePayload;
 
+// MPToken Background Messages
+export type ReceiveAuthorizeMPTokenBackgroundMessage = ReceiveAuthorizeMPTokenContentMessage &
+  BackgroundMessagePayload;
+
+export type ReceiveCreateMPTokenIssuanceBackgroundMessage =
+  ReceiveCreateMPTokenIssuanceContentMessage & BackgroundMessagePayload;
+
+export type ReceiveDestroyMPTokenIssuanceBackgroundMessage =
+  ReceiveDestroyMPTokenIssuanceContentMessage & BackgroundMessagePayload;
+
+export type ReceiveSetMPTokenIssuanceBackgroundMessage = ReceiveSetMPTokenIssuanceContentMessage &
+  BackgroundMessagePayload;
+
 export type InternalReceivePasswordBackgroundMessage = InternalReceivePasswordContentMessage &
   BackgroundMessagePayload;
 
@@ -712,6 +799,10 @@ export type BackgroundMessage =
   | RequestSignTransactionMessage
   | RequestSubmitTransactionMessage
   | RequestSubmitBulkTransactionsMessage
+  | RequestAuthorizeMPTokenMessage
+  | RequestCreateMPTokenIssuanceMessage
+  | RequestDestroyMPTokenIssuanceMessage
+  | RequestSetMPTokenIssuanceMessage
   // Outputted Messages - DO contain ID within the payloads
   | EventLoginBackgroundMessage
   | EventLogoutBackgroundMessage
@@ -744,6 +835,10 @@ export type BackgroundMessage =
   | ReceiveSignTransactionBackgroundMessage
   | ReceiveSubmitTransactionBackgroundMessage
   | ReceiveSubmitBulkTransactionsBackgroundMessage
+  | ReceiveAuthorizeMPTokenBackgroundMessage
+  | ReceiveCreateMPTokenIssuanceBackgroundMessage
+  | ReceiveDestroyMPTokenIssuanceBackgroundMessage
+  | ReceiveSetMPTokenIssuanceBackgroundMessage
   //
   // Internal message - Messages between the extension and the background script
   //
@@ -780,4 +875,8 @@ export type APIMessages =
   | RequestSignMessageMessage
   | RequestSignTransactionMessage
   | RequestSubmitTransactionMessage
-  | RequestSubmitBulkTransactionsMessage;
+  | RequestSubmitBulkTransactionsMessage
+  | RequestAuthorizeMPTokenMessage
+  | RequestCreateMPTokenIssuanceMessage
+  | RequestDestroyMPTokenIssuanceMessage
+  | RequestSetMPTokenIssuanceMessage;

--- a/packages/constants/src/payload/payload.types.ts
+++ b/packages/constants/src/payload/payload.types.ts
@@ -312,6 +312,44 @@ export interface SetHookRequest extends BaseTransactionRequest {
   hooks: Hook[];
 }
 
+/*
+ * MPToken Requests
+ */
+
+export interface AuthorizeMPTokenRequest extends BaseTransactionRequest {
+  // The MPTokenIssuanceID of the MPToken to authorize or unauthorize.
+  MPTokenIssuanceID: string;
+}
+
+export interface CreateMPTokenIssuanceRequest extends BaseTransactionRequest {
+  // An integer in the range 0-9 indicating the maximum number of decimal places the token can have.
+  assetScale?: number;
+  // The maximum number of this token that can ever exist. If not set, there is no limit.
+  maximumAmount?: string;
+  // The fee to charge when users transfer this token, represented as billionths of a unit.
+  // Valid values are 0 to 50000000000 (0% to 50%).
+  transferFee?: number;
+  // Arbitrary metadata about this issuance, in hex format.
+  // This should be XLS-89 compliant JSON converted to hex.
+  MPTokenMetadata?: string;
+  // Flags for the issuance (e.g., locking, authorization requirements, transfer permissions).
+  flags?: number;
+}
+
+export interface DestroyMPTokenIssuanceRequest extends BaseTransactionRequest {
+  // The MPTokenIssuanceID of the MPToken issuance to destroy.
+  MPTokenIssuanceID: string;
+}
+
+export interface SetMPTokenIssuanceRequest extends BaseTransactionRequest {
+  // The MPTokenIssuanceID of the MPToken issuance to modify.
+  MPTokenIssuanceID: string;
+  // The account address of a holder whose tokens should be locked/unlocked.
+  holder?: string;
+  // Flags for lock/unlock operations.
+  flags?: number;
+}
+
 export type RequestPayload =
   | AcceptNFTOfferRequest
   | BurnNFTRequest
@@ -334,7 +372,11 @@ export type RequestPayload =
   | SignTransactionRequest
   | SubmitStorageKeyRequest
   | SubmitTransactionRequest
-  | SubmitBulkTransactionsWithKeysRequest;
+  | SubmitBulkTransactionsWithKeysRequest
+  | AuthorizeMPTokenRequest
+  | CreateMPTokenIssuanceRequest
+  | DestroyMPTokenIssuanceRequest
+  | SetMPTokenIssuanceRequest;
 
 /*
  * Response Payloads
@@ -475,6 +517,30 @@ export interface SetHookResponse
     hash: string;
   }> {}
 
+/*
+ * MPToken Responses
+ */
+
+export interface AuthorizeMPTokenResponse
+  extends BaseResponse<{
+    hash: string;
+  }> {}
+
+export interface CreateMPTokenIssuanceResponse
+  extends BaseResponse<{
+    hash: string;
+  }> {}
+
+export interface DestroyMPTokenIssuanceResponse
+  extends BaseResponse<{
+    hash: string;
+  }> {}
+
+export interface SetMPTokenIssuanceResponse
+  extends BaseResponse<{
+    hash: string;
+  }> {}
+
 export type ResponsePayload =
   | AcceptNFTOfferResponse
   | BurnNFTResponse
@@ -502,7 +568,11 @@ export type ResponsePayload =
   | SignMessageResponse
   | SignMessageResponseDeprecated
   | SubmitTransactionResponse
-  | SubmitBulkTransactionsResponse;
+  | SubmitBulkTransactionsResponse
+  | AuthorizeMPTokenResponse
+  | CreateMPTokenIssuanceResponse
+  | DestroyMPTokenIssuanceResponse
+  | SetMPTokenIssuanceResponse;
 
 /*
  * Internal Messages Payloads


### PR DESCRIPTION
## Summary

- Add MPToken API functions for dApps to interact with Multi-Purpose Tokens
- Provides complete API coverage for all MPToken transaction types

## New API Functions

### authorizeMPToken
Allows users to authorize holding a specific MPToken.

### createMPTokenIssuance
Allows issuers to create new MPToken issuances with configurable properties:
- Asset scale (decimal places)
- Maximum amount (supply cap)
- Transfer fee
- Metadata (XLS-89 compliant)
- Capability flags (lock, auth, escrow, trade, transfer, clawback)

### destroyMPTokenIssuance
Allows issuers to permanently destroy an MPToken issuance (when supply is zero).

### setMPTokenIssuance
Allows issuers to modify issuance settings, specifically to lock/unlock tokens for specific holders.

## Type Definitions

All request/response types follow the existing patterns:
- `AuthorizeMPTokenRequest/Response`
- `CreateMPTokenIssuanceRequest/Response`
- `DestroyMPTokenIssuanceRequest/Response`
- `SetMPTokenIssuanceRequest/Response`

## Message Types

Added V3 message types for all operations:
- `REQUEST_AUTHORIZE_MPTOKEN/V3`
- `REQUEST_CREATE_MPTOKEN_ISSUANCE/V3`
- `REQUEST_DESTROY_MPTOKEN_ISSUANCE/V3`
- `REQUEST_SET_MPTOKEN_ISSUANCE/V3`

## Test plan

- [ ] Verify authorizeMPToken API works correctly
- [ ] Verify createMPTokenIssuance API works correctly
- [ ] Verify destroyMPTokenIssuance API works correctly
- [ ] Verify setMPTokenIssuance API works correctly
- [ ] Verify TypeScript types are correctly exported